### PR TITLE
chore: update Docker image to v0.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     container_name: service-quality-oracle
 
     # Set the image name
-    image: ghcr.io/graphprotocol/service-quality-oracle:v0.3.0
+    image: ghcr.io/graphprotocol/rewards-eligibility-oracle:v0.3.0
 
     volumes:
       # Mount data directory to store data


### PR DESCRIPTION
## Changes

Update `docker-compose.yml` to use the new v0.3.0 Docker image release.

## What's in v0.3.0

The v0.3.0 release includes:
- Python 3.13.7 upgrade
- Updated Python dependencies (13 packages)
- gql 3.5.3 → 4.0.0
- Google Cloud credential handling improvements
- Security updates

Related: #30 (Python 3.13.7 upgrade)