### PR TITLE
fix: configure release-please workflow to use config files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v4
-        with:
-          release-type: python
-          package-name: rewards-eligibility-oracle

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: rewards-eligibility-oracle
-        image: ghcr.io/graphprotocol/rewards-eligibility-oracle:v0.4.0
+        image: ghcr.io/graphprotocol/rewards-eligibility-oracle:v0.4.1 # x-release-please-version
         envFrom:
         # Load all non-sensitive configuration from ConfigMap
         - configMapRef:


### PR DESCRIPTION
## Summary

Fixes the release-please configuration issue misconfiguration in PR #49 that lead to automated release-please PR #52 which didnt bump the version number in the docker-compose.yml or kubernetes files. The GitHub Actions workflow was explicitly passing `release-type` and `package-name` parameters, which caused release-please to completely ignore `.release-please-config.json`. This prevented the `extra-files` configuration from working, so Docker image versions were never automatically updated.