### PR TITLE
fix: configure release-please correctly to unblock release pipeline

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "packages": {
     ".": {
-      "release-type": "python",
+      "release-type": "simple",
       "package-name": "rewards-eligibility-oracle",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
### Summary
Fixes the broken release pipeline by aligning the configuration with `release-please-action` defaults and removing the Python version dependency.

### Changes
- **Renamed Config File:** Moved `.release-please-config.json` -> `release-please-config.json`. 
  - *Reason:* The v4 action looks for the non-dotted filename by default.
- **Updated Release Type:** Changed from `python` to `simple`.
  - *Reason:* The `python` type requires a `version` field in `pyproject.toml` or `setup.py`, which we do not use (we are a Docker-based deployment). The `simple` type relies solely on the manifest file, which correctly matches our workflow.

### Impact
This will trigger the pending release (v0.4.2) that should have been created after recent fixes were merged.