### PR TITLE
fix: remove package-name from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "rewards-eligibility-oracle",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary

Removes the `package-name` field from `release-please-config.json` to fix Docker image builds.

## Problem

The v0.4.2 release created a tag `rewards-eligibility-oracle-v0.4.2` instead of `v0.4.2` because of the `package-name` configuration. The CD workflow only triggers on tags matching `v*.*.*`, so no Docker image was built.

## Solution

Remove `package-name` from the config. Future releases will create tags in the correct format (`v*.*.*`) that trigger the CD workflow and build Docker images.

## Impact

The next release (v0.4.3) will have the correct tag format and will automatically build and publish the Docker image.