### PR TITLE
fix: remove unused config keys and subgraph URLs

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,4 @@
-# Rewards Eligibility Configuration
+# Rewards Eligibility Oracle Configuration
 # This file separates sensitive secrets from non-sensitive configuration values
 
 # =============================================================================
@@ -6,30 +6,30 @@
 # =============================================================================
 
 [bigquery]
-BIGQUERY_LOCATION_ID = ""
-BIGQUERY_PROJECT_ID = ""
-BIGQUERY_DATASET_ID = ""
-BIGQUERY_TABLE_ID = ""
+BIGQUERY_LOCATION_ID = "US"
+BIGQUERY_PROJECT_ID = "graph-mainnet"
+BIGQUERY_DATASET_ID = "internal_metrics"
+BIGQUERY_TABLE_ID = "metrics_indexer_attempts"
+BIGQUERY_CURATION_TABLE_ID = "metrics_curator_signals"
+BIGQUERY_CURATOR_MAINNET_TABLE_ID = "curator_name_signal_dimensions_daily"
+BIGQUERY_CURATOR_ARBITRUM_TABLE_ID = "curator_name_signal_dimensions_arbitrum_daily"
+BIGQUERY_SUBGRAPH_LOOKUP_TABLE_ID = "subgraph_version_id_lookup"
 
 [blockchain]
-BLOCKCHAIN_CONTRACT_ADDRESS = ""
+BLOCKCHAIN_CONTRACT_ADDRESS = "0x9BED32d2b562043a426376b99d289fE821f5b04E"
 BLOCKCHAIN_FUNCTION_NAME = "renewIndexerEligibility"
-BLOCKCHAIN_CHAIN_ID = ""
+BLOCKCHAIN_CHAIN_ID = 421614
 BLOCKCHAIN_RPC_URLS = [
-    "",
-    "",
-    "",
-    ""
+    "https://arbitrum-sepolia.drpc.org",
+    "https://sepolia-rollup.arbitrum.io/rpc",
+    "https://api.zan.top/arb-sepolia",
+    "https://arbitrum-sepolia.gateway.tenderly.co"
 ]
 BLOCK_EXPLORER_URL = "https://sepolia.arbiscan.io"
 TX_TIMEOUT_SECONDS = "30"
 
 [scheduling]
 SCHEDULED_RUN_TIME = "10:00"
-
-[subgraph]
-SUBGRAPH_URL_PRE_PRODUCTION = ""
-SUBGRAPH_URL_PRODUCTION = ""
 
 [processing]
 BATCH_SIZE = 125
@@ -55,8 +55,6 @@ MAX_BLOCKS_BEHIND = "50000"
 [secrets]
 GOOGLE_APPLICATION_CREDENTIALS = "$GOOGLE_APPLICATION_CREDENTIALS"
 BLOCKCHAIN_PRIVATE_KEY = "$BLOCKCHAIN_PRIVATE_KEY"
-ETHERSCAN_API_KEY = "$ETHERSCAN_API_KEY" 
+ETHERSCAN_API_KEY = "$ETHERSCAN_API_KEY"
 ARBITRUM_API_KEY = "$ARBITRUM_API_KEY"
-STUDIO_API_KEY = "$STUDIO_API_KEY"
-STUDIO_DEPLOY_KEY = "$STUDIO_DEPLOY_KEY"
 SLACK_WEBHOOK_URL = "$SLACK_WEBHOOK_URL"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -39,10 +39,6 @@ data:
     [scheduling]
     SCHEDULED_RUN_TIME = "10:00"
 
-    [subgraph]
-    SUBGRAPH_URL_PRE_PRODUCTION = "https://api.studio.thegraph.com/query/110664/issuance-eligibility-oracle/v0.1.4"
-    SUBGRAPH_URL_PRODUCTION = "https://gateway.thegraph.com/api/subgraphs/id/"
-
     [processing]
     BATCH_SIZE = 125
     MAX_AGE_BEFORE_DELETION = 120
@@ -59,7 +55,6 @@ data:
     MIN_SUBGRAPHS = "1"
     MAX_LATENCY_MS = "5000"
     MAX_BLOCKS_BEHIND = "50000"
-    MIN_CURATION_SIGNAL = "500"
 
     # =============================================================================
     # SENSITIVE CONFIGURATION
@@ -70,6 +65,4 @@ data:
     BLOCKCHAIN_PRIVATE_KEY = "$BLOCKCHAIN_PRIVATE_KEY"
     ETHERSCAN_API_KEY = "$ETHERSCAN_API_KEY"
     ARBITRUM_API_KEY = "$ARBITRUM_API_KEY"
-    STUDIO_API_KEY = "$STUDIO_API_KEY"
-    STUDIO_DEPLOY_KEY = "$STUDIO_DEPLOY_KEY"
     SLACK_WEBHOOK_URL = "$SLACK_WEBHOOK_URL"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -42,16 +42,6 @@ spec:
             secretKeyRef:
               name: rewards-eligibility-oracle-secrets
               key: arbitrum-api-key
-        - name: STUDIO_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: rewards-eligibility-oracle-secrets
-              key: studio-api-key
-        - name: STUDIO_DEPLOY_KEY
-          valueFrom:
-            secretKeyRef:
-              name: rewards-eligibility-oracle-secrets
-              key: studio-deploy-key
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:

--- a/src/utils/configuration.py
+++ b/src/utils/configuration.py
@@ -165,12 +165,6 @@ class ConfigLoader:
             # Scheduling
             "SCHEDULED_RUN_TIME": substituted_config.get("scheduling", {}).get("SCHEDULED_RUN_TIME"),
 
-            # Subgraph URLs
-            "SUBGRAPH_URL_PRE_PRODUCTION": substituted_config.get("subgraph", {}).get(
-                "SUBGRAPH_URL_PRE_PRODUCTION"
-            ),
-            "SUBGRAPH_URL_PRODUCTION": substituted_config.get("subgraph", {}).get("SUBGRAPH_URL_PRODUCTION"),
-
             # Processing settings
             "BATCH_SIZE": to_int(substituted_config.get("processing", {}).get("BATCH_SIZE")),
             "MAX_AGE_BEFORE_DELETION": to_int(
@@ -185,8 +179,6 @@ class ConfigLoader:
                 "GOOGLE_APPLICATION_CREDENTIALS"
             ),
             "PRIVATE_KEY": substituted_config.get("secrets", {}).get("BLOCKCHAIN_PRIVATE_KEY"),
-            "STUDIO_API_KEY": substituted_config.get("secrets", {}).get("STUDIO_API_KEY"),
-            "STUDIO_DEPLOY_KEY": substituted_config.get("secrets", {}).get("STUDIO_DEPLOY_KEY"),
             "SLACK_WEBHOOK_URL": substituted_config.get("secrets", {}).get("SLACK_WEBHOOK_URL"),
             "ETHERSCAN_API_KEY": substituted_config.get("secrets", {}).get("ETHERSCAN_API_KEY"),
             "ARBITRUM_API_KEY": substituted_config.get("secrets", {}).get("ARBITRUM_API_KEY"),
@@ -259,8 +251,6 @@ def _validate_config(config: dict[str, Any]) -> dict[str, Any]:
         "BLOCK_EXPLORER_URL",
         "TX_TIMEOUT_SECONDS",
         "SCHEDULED_RUN_TIME",
-        "SUBGRAPH_URL_PRE_PRODUCTION",
-        "SUBGRAPH_URL_PRODUCTION",
         "BATCH_SIZE",
         "MAX_AGE_BEFORE_DELETION",
         "BIGQUERY_ANALYSIS_PERIOD_DAYS",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -24,7 +24,6 @@ from src.utils.configuration import (
 MOCK_TOML_CONFIG = """
 [secrets]
 BLOCKCHAIN_PRIVATE_KEY = "$TEST_PRIVATE_KEY"
-STUDIO_API_KEY = "$STUDIO_API_KEY"
 
 [scheduling]
 SCHEDULED_RUN_TIME = "10:00"
@@ -103,8 +102,6 @@ def full_valid_config() -> dict:
         "BIGQUERY_ANALYSIS_PERIOD_DAYS": 28,
         "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/creds.json",  # Added for completeness
         "PRIVATE_KEY": "0x123",
-        "STUDIO_API_KEY": "key",
-        "STUDIO_DEPLOY_KEY": "key",
         "SLACK_WEBHOOK_URL": "http://slack.com",
         "ETHERSCAN_API_KEY": "key",
         "ARBITRUM_API_KEY": "key",
@@ -123,7 +120,6 @@ def temp_config_file(tmp_path: Path) -> str:
 def mock_env(monkeypatch):
     """A fixture to mock standard environment variables."""
     monkeypatch.setenv("TEST_PRIVATE_KEY", "0x12345")
-    monkeypatch.setenv("STUDIO_API_KEY", "studio-key")
     return monkeypatch
 
 
@@ -168,7 +164,6 @@ class TestConfigLoader:
 
         # Assert
         assert config["PRIVATE_KEY"] == "0x12345"
-        assert config["STUDIO_API_KEY"] == "studio-key"
         assert config["SCHEDULED_RUN_TIME"] == "10:00"
         assert config["BIGQUERY_PROJECT_ID"] == "test-project"
         assert config["BLOCKCHAIN_RPC_URLS"] == ["http://main.com", "http://backup.com"]
@@ -333,12 +328,11 @@ class TestConfigLoader:
         """
         # Arrange
         monkeypatch.delenv("TEST_PRIVATE_KEY", raising=False)
-        monkeypatch.delenv("STUDIO_API_KEY", raising=False)
         loader = ConfigLoader(config_path=temp_config_file)
         # Act
         missing = loader.get_missing_env_vars()
         # Assert
-        assert sorted(missing) == sorted(["TEST_PRIVATE_KEY", "STUDIO_API_KEY"])
+        assert sorted(missing) == sorted(["TEST_PRIVATE_KEY"])
 
 
     @pytest.mark.parametrize(

--- a/tests/test_service_quality_oracle.py
+++ b/tests/test_service_quality_oracle.py
@@ -36,8 +36,6 @@ MOCK_CONFIG = {
     "SCHEDULED_RUN_TIME": "10:00",
     "SUBGRAPH_URL_PRE_PRODUCTION": "http://fake.url",
     "SUBGRAPH_URL_PRODUCTION": "http://fake.url",
-    "STUDIO_API_KEY": "fake-api-key",
-    "STUDIO_DEPLOY_KEY": "fake-deploy-key",
     "ETHERSCAN_API_KEY": "fake-etherscan-key",
     "ARBITRUM_API_KEY": "fake-arbitrum-key",
 }


### PR DESCRIPTION
Removes unused configuration fields that were causing deployment failures in Kubernetes.

## Changes
- Remove `STUDIO_API_KEY` and `STUDIO_DEPLOY_KEY` (never used in application logic)
- Remove `SUBGRAPH_URL_PRE_PRODUCTION` and `SUBGRAPH_URL_PRODUCTION` from required fields
- Update Kubernetes ConfigMap and Deployment manifests
- Update tests to reflect removed fields

## Impact
Fixes pod CrashLoopBackOff in Kubernetes due to missing environment variables for unused keys.