### PR TITLE
feat(ci): self-healing release version sync for release-please

### DIFF
--- a/.github/actions/sync-manifest/action.yml
+++ b/.github/actions/sync-manifest/action.yml
@@ -1,0 +1,78 @@
+name: 'Sync Release Manifest'
+description: 'Check for and optionally fix drift between git tags and release-please manifest'
+
+inputs:
+  auto-commit:
+    description: 'Whether to automatically commit and push manifest updates'
+    required: false
+    default: 'true'
+
+outputs:
+  drift:
+    description: 'Whether manifest drift was detected'
+    value: ${{ steps.check.outputs.drift }}
+  latest-version:
+    description: 'Latest version from git tags'
+    value: ${{ steps.check.outputs.latest_version }}
+  manifest-version:
+    description: 'Version currently in manifest'
+    value: ${{ steps.check.outputs.manifest_version }}
+  synced:
+    description: 'Whether the manifest was synced'
+    value: ${{ steps.update.outputs.synced || 'false' }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for manifest drift
+      id: check
+      shell: bash
+      run: |
+        # Get latest tag (with fallback if no tags exist)
+        LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || echo "v0.0.0")
+        LATEST_VERSION="${LATEST_TAG#v}"
+
+        # Get manifest version (with error handling for missing/invalid file)
+        MANIFEST_VERSION=$(jq -r '.["."] // "0.0.0"' .release-please-manifest.json 2>/dev/null || echo "0.0.0")
+
+        echo "Latest tag: $LATEST_TAG ($LATEST_VERSION)"
+        echo "Manifest version: $MANIFEST_VERSION"
+
+        # Check if they match
+        if [ "$LATEST_VERSION" != "$MANIFEST_VERSION" ]; then
+          echo "drift=true" >> $GITHUB_OUTPUT
+          echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          echo "manifest_version=$MANIFEST_VERSION" >> $GITHUB_OUTPUT
+          echo "Drift detected - manifest needs update"
+        else
+          echo "drift=false" >> $GITHUB_OUTPUT
+          echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          echo "manifest_version=$MANIFEST_VERSION" >> $GITHUB_OUTPUT
+          echo "Manifest is in sync with tags"
+        fi
+
+    - name: Update manifest if drifted
+      id: update
+      if: steps.check.outputs.drift == 'true' && inputs.auto-commit == 'true'
+      shell: bash
+      run: |
+        VERSION="${{ steps.check.outputs.latest_version }}"
+
+        # Update manifest (with error handling for missing/invalid file)
+        if ! jq --arg version "$VERSION" '.["."] = $version' .release-please-manifest.json > manifest.tmp 2>/dev/null; then
+          echo "Warning: Could not update manifest, creating new one"
+          echo "{\".\": \"$VERSION\"}" > manifest.tmp
+        fi
+        mv manifest.tmp .release-please-manifest.json
+
+        # Configure git
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        # Commit and push
+        git add .release-please-manifest.json
+        git commit -m "chore: auto-sync manifest to $VERSION (was ${{ steps.check.outputs.manifest_version }}) [skip ci]"
+        git push origin main
+
+        echo "synced=true" >> $GITHUB_OUTPUT
+        echo "Manifest synced: ${{ steps.check.outputs.manifest_version }} -> $VERSION"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -140,10 +140,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create tag
+      - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update release-please manifest
+        run: |
+          # Update .release-please-manifest.json to keep release-please in sync
+          VERSION="${{ needs.version.outputs.version }}"
+          VERSION_NO_V="${VERSION#v}"
+
+          # Update manifest file (with error handling for missing/invalid file)
+          if ! jq --arg version "$VERSION_NO_V" '.["."] = $version' .release-please-manifest.json > manifest.tmp 2>/dev/null; then
+            echo "Warning: Could not update manifest, creating new one"
+            echo "{\".\": \"$VERSION_NO_V\"}" > manifest.tmp
+          fi
+          mv manifest.tmp .release-please-manifest.json
+
+          # Commit manifest update
+          git add .release-please-manifest.json
+          git commit -m "chore: sync manifest with manual release $VERSION [skip ci]"
+          git push origin main
+
+      - name: Create tag
+        run: |
           git tag ${{ needs.version.outputs.version }}
           git push origin ${{ needs.version.outputs.version }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  # First, sync manifest with actual tags to prevent drift
+  sync-manifest:
+    runs-on: ubuntu-latest
+    # Skip if commit was from github-actions bot to prevent circular triggers
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync manifest with tags
+        uses: ./.github/actions/sync-manifest
+
   release-please:
     runs-on: ubuntu-latest
+    needs: sync-manifest
+    # Run even if sync-manifest was skipped (bot commits)
+    if: always() && (needs.sync-manifest.result == 'success' || needs.sync-manifest.result == 'skipped')
     steps:
       - uses: google-github-actions/release-please-action@v4

--- a/.github/workflows/sync-release-manifest.yml
+++ b/.github/workflows/sync-release-manifest.yml
@@ -1,0 +1,41 @@
+name: Sync Release Manifest
+
+# Auto-heal release-please manifest if it drifts from actual tags
+# Runs daily and can be triggered manually
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  sync-manifest:
+    name: Sync Manifest with Git Tags
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync manifest with tags
+        id: sync
+        uses: ./.github/actions/sync-manifest
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.sync.outputs.drift }}" == "true" ]; then
+            echo "### Manifest Auto-Synced" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- **Previous version:** ${{ steps.sync.outputs.manifest-version }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Latest tag:** ${{ steps.sync.outputs.latest-version }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **Action:** Manifest updated automatically" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Manifest In Sync" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No action needed. Manifest matches latest tag." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

Adds automatic synchronization between git tags and the release-please manifest to prevent version drift. This addresses cases where manual releases or workflow bypasses cause the manifest to fall out of sync with actual tags.

## Changes

- **New composite action** (`.github/actions/sync-manifest/`) - Reusable drift detection and auto-fix logic with error handling
- **Updated release-please.yml** - Runs sync before release-please on every PR merge to main
- **New sync-release-manifest.yml** - Daily cron + manual trigger as backup catchall  
- **Updated cd.yml** - Syncs manifest during manual hotfix releases

## How it works

1. Compares latest semver git tag against `.release-please-manifest.json`
2. If mismatched, updates manifest and commits with `[skip ci]`
3. Skips when triggered by bot commits to prevent circular triggers