### PR TITLE
fix: extend circuit breaker window from 60 minutes to 12 hours

### DIFF
--- a/src/models/rewards_eligibility_oracle.py
+++ b/src/models/rewards_eligibility_oracle.py
@@ -49,7 +49,7 @@ def main(run_date_override: date = None):
     circuit_breaker_log = project_root_path / "data" / "circuit_breaker.log"
     circuit_breaker = CircuitBreaker(
         failure_threshold=3,
-        window_minutes=60,
+        window_minutes=720,
         log_file=circuit_breaker_log,
     )
 


### PR DESCRIPTION
## Summary

The 60-minute window caused excessive retry attempts during persistent failures. The circuit breaker would reopen every hour, allowing 3 more failures - resulting in ~36 failed attempts per day, each incurring BigQuery costs and potentially wasted gas.

## Test plan

- [x] Existing tests pass

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)