### PR TITLE
fix(ci): fix YAML syntax error in sync-manifest action breaking release-please

### DIFF
--- a/.github/actions/sync-manifest/action.yml
+++ b/.github/actions/sync-manifest/action.yml
@@ -96,15 +96,16 @@ runs:
         git commit -m "chore: sync manifest to $VERSION (was $OLD_VERSION)"
         git push -u origin "$BRANCH"
 
-        # Create PR
+        # Create PR body using printf to avoid YAML parsing issues with markdown
+        PR_BODY=$(printf '%s\n\n%s\n%s\n\n%s' \
+          "Auto-generated PR to sync release-please manifest with git tags." \
+          "- **Previous version:** $OLD_VERSION" \
+          "- **Target version:** $VERSION" \
+          "This PR was created because the manifest version fell behind the latest git tag, likely due to a manual release.")
+
         gh pr create \
           --title "chore: sync release-please manifest to $VERSION" \
-          --body "Auto-generated PR to sync release-please manifest with git tags.
-
-- **Previous version:** $OLD_VERSION
-- **Target version:** $VERSION
-
-This PR was created because the manifest version fell behind the latest git tag, likely due to a manual release." \
+          --body "$PR_BODY" \
           --base main \
           --head "$BRANCH"
 


### PR DESCRIPTION
## Summary

Fixes a YAML syntax error in the sync-manifest action introduced in #96 that has been breaking the release-please workflow.

The markdown list items (`- **Previous version:**`) in the `gh pr create --body` argument were being interpreted as YAML list items by the GitHub Actions parser, causing the workflow to fail with:

```
yaml: line 104: could not find expected ':'
```

Note: release-please has actually been failing since #74 introduced sync-manifest - initially due to branch protection blocking direct pushes to main, then after #96's fix attempt, due to this YAML syntax error.

## Changes

- Use `printf` to construct the PR body as a variable, keeping all content on properly indented lines
- This prevents the YAML parser from misinterpreting markdown list items as YAML structure

---

Generated with [Claude Code](https://claude.ai/code)