### PR TITLE
feat: mark each Slack notification with its network

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ docker-compose ps
 ```bash
 # Test Slack webhook
 export SLACK_WEBHOOK_URL="your_webhook_url"
+# Optional: label the test messages with a network, e.g. 42161 for mainnet or 421614 for testnet
+export BLOCKCHAIN_CHAIN_ID="421614"
 ./scripts/test_slack_notifications.py
 ```
 

--- a/scripts/test_slack_notifications.py
+++ b/scripts/test_slack_notifications.py
@@ -122,7 +122,13 @@ def run_all_tests() -> bool:
         logger.error("SLACK_WEBHOOK_URL environment variable not set. Cannot run tests.")
         return False
 
-    notifier = create_slack_notifier(webhook_url)
+    # Optional, so the test messages carry the same network label a real deployment would send
+    chain_id_env = os.environ.get("BLOCKCHAIN_CHAIN_ID")
+    if chain_id_env and not chain_id_env.isdigit():
+        logger.error(f"BLOCKCHAIN_CHAIN_ID must be a number, got: {chain_id_env}")
+        return False
+
+    notifier = create_slack_notifier(webhook_url, int(chain_id_env) if chain_id_env else None)
     if not notifier:
         logger.error("Failed to create Slack notifier. Check webhook URL or network.")
         return False

--- a/src/models/rewards_eligibility_oracle.py
+++ b/src/models/rewards_eligibility_oracle.py
@@ -63,7 +63,7 @@ def main(run_date_override: date = None):
     try:
         # Configuration and credentials
         config = load_config()
-        slack_notifier = create_slack_notifier(config.get("SLACK_WEBHOOK_URL"))
+        slack_notifier = create_slack_notifier(config.get("SLACK_WEBHOOK_URL"), config.get("BLOCKCHAIN_CHAIN_ID"))
         opsgenie_api_key = config.get("OPSGENIE_API_KEY")
 
         if slack_notifier:

--- a/src/models/scheduler.py
+++ b/src/models/scheduler.py
@@ -156,6 +156,8 @@ class Scheduler:
     def initialize(self):
         """Initialize the scheduler and validate configuration"""
         logger.info("Initializing scheduler...")
+        config = None
+
         try:
             validate_all_required_env_vars()
 
@@ -175,7 +177,9 @@ class Scheduler:
             config = load_config()
 
             # Create Slack notifier
-            self.slack_notifier = create_slack_notifier(config.get("SLACK_WEBHOOK_URL"))
+            self.slack_notifier = create_slack_notifier(
+                config.get("SLACK_WEBHOOK_URL"), config.get("BLOCKCHAIN_CHAIN_ID")
+            )
             if self.slack_notifier:
                 logger.info("Slack notifications enabled for scheduler")
                 startup_message = (
@@ -212,7 +216,9 @@ class Scheduler:
             if not self.slack_notifier:
                 webhook_url = os.environ.get("SLACK_WEBHOOK_URL")
                 if webhook_url:
-                    self.slack_notifier = create_slack_notifier(webhook_url)
+                    # Config may not have loaded yet, in which case the network stays unknown
+                    chain_id = config.get("BLOCKCHAIN_CHAIN_ID") if config else None
+                    self.slack_notifier = create_slack_notifier(webhook_url, chain_id)
 
             if self.slack_notifier:
                 self.slack_notifier.send_failure_notification(

--- a/src/utils/slack_notifier.py
+++ b/src/utils/slack_notifier.py
@@ -14,19 +14,45 @@ from src.utils.retry_decorator import retry_with_backoff
 # Module-level logger
 logger = logging.getLogger(__name__)
 
+# Prefixes that tell readers which network a notification came from, keyed by the chain the oracle posts to
+NETWORK_LABELS = {
+    42161: "[MAINNET] :large_green_circle:",
+    421614: "[TESTNET] :large_brown_circle:",
+}
+
+
+def get_network_label(chain_id: Optional[int]) -> str:
+    """
+    Get the prefix that identifies which network a notification is about, empty if the chain is unknown.
+    """
+    # Without a chain we cannot say which network the message is about, so send it unlabelled
+    if chain_id is None:
+        logger.debug("No chain ID available - Slack notifications will not be labelled with a network")
+        return ""
+
+    label = NETWORK_LABELS.get(chain_id)
+
+    # Fall back to the raw chain ID so an unrecognised network is still visible rather than silently unlabelled
+    if label is None:
+        logger.warning(f"No network label defined for chain ID {chain_id} - labelling with the chain ID instead")
+        return f"[CHAIN {chain_id}]"
+
+    return label
+
 
 class SlackNotifier:
     """Simple utility class for sending notifications to Slack via webhooks."""
 
-    def __init__(self, webhook_url: str) -> None:
+    def __init__(self, webhook_url: str, chain_id: Optional[int] = None) -> None:
         """
-        Initialize the Slack notifier.
+        Initialize the Slack notifier, labelling every notification with the network the chain ID maps to.
 
         Args:
             webhook_url: The Slack webhook URL to send notifications to.
         """
         self.webhook_url = webhook_url
         self.timeout = 10  # seconds
+        self.network_label = get_network_label(chain_id)
 
 
     @retry_with_backoff(
@@ -69,9 +95,9 @@ class SlackNotifier:
 
 
     def _create_payload(self, text: str, fields: List[Dict], color: str = "good") -> Dict:
-        """Create a Slack message payload."""
+        """Create a Slack message payload, led by the network label so readers can tell the deployments apart."""
         return {
-            "text": text,
+            "text": f"{self.network_label} {text}" if self.network_label else text,
             "attachments": [
                 {
                     "color": color,
@@ -256,20 +282,17 @@ class SlackNotifier:
         return self._send_message(payload)
 
 
-def create_slack_notifier(webhook_url: Optional[str]) -> Optional[SlackNotifier]:
+def create_slack_notifier(webhook_url: Optional[str], chain_id: Optional[int] = None) -> Optional[SlackNotifier]:
     """
-    Factory function to create a SlackNotifier instance.
+    Create a SlackNotifier for the given webhook, or None when no webhook URL is configured.
 
     Args:
-        webhook_url: The Slack webhook URL (can be None)
-
-    Returns:
-        SlackNotifier instance if webhook_url is provided, None otherwise
+        chain_id: The chain the oracle posts to, used to label notifications by network (can be None)
     """
     # If the webhook URL is provided, create a SlackNotifier instance
     if webhook_url and webhook_url.strip():
         try:
-            return SlackNotifier(webhook_url.strip())
+            return SlackNotifier(webhook_url.strip(), chain_id)
 
         # If there is an error when trying to create the SlackNotifier instance, return None
         except Exception as e:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -16,6 +16,7 @@ from src.utils.configuration import ConfigurationError
 MOCK_CONFIG = {
     "SLACK_WEBHOOK_URL": "http://fake.slack.com",
     "SCHEDULED_RUN_TIME": "10:00",
+    "BLOCKCHAIN_CHAIN_ID": 421614,
 }
 
 MOCK_CONFIG_NO_SLACK = {"SCHEDULED_RUN_TIME": "10:00", "SLACK_WEBHOOK_URL": None}
@@ -99,7 +100,9 @@ class TestSchedulerInitialization:
             mock_dependencies.validate.assert_called_once()
             mock_dependencies.creds.get_google_credentials.assert_called_once()
             mock_dependencies.load_config.assert_called_once()
-            mock_dependencies.create_slack.assert_called_once_with(MOCK_CONFIG["SLACK_WEBHOOK_URL"])
+            mock_dependencies.create_slack.assert_called_once_with(
+                MOCK_CONFIG["SLACK_WEBHOOK_URL"], MOCK_CONFIG["BLOCKCHAIN_CHAIN_ID"]
+            )
             mock_dependencies.os.environ.get.assert_any_call("RUN_ON_STARTUP", "false")
             mock_dependencies.schedule.every.return_value.day.at.assert_called_once_with(
                 MOCK_CONFIG["SCHEDULED_RUN_TIME"]
@@ -118,7 +121,8 @@ class TestSchedulerInitialization:
 
         Scheduler()
 
-        mock_dependencies.create_slack.assert_called_once_with(MOCK_CONFIG["SLACK_WEBHOOK_URL"])
+        # Configuration never loaded, so the network is unknown and the notification goes out unlabelled
+        mock_dependencies.create_slack.assert_called_once_with(MOCK_CONFIG["SLACK_WEBHOOK_URL"], None)
         mock_dependencies.slack_notifier.send_failure_notification.assert_called_once()
         mock_dependencies.exit.assert_called_once_with(1)
 
@@ -130,7 +134,8 @@ class TestSchedulerInitialization:
 
         Scheduler()
 
-        mock_dependencies.create_slack.assert_called_once_with(MOCK_CONFIG["SLACK_WEBHOOK_URL"])
+        # Configuration failed to load, so the network is unknown and the notification goes out unlabelled
+        mock_dependencies.create_slack.assert_called_once_with(MOCK_CONFIG["SLACK_WEBHOOK_URL"], None)
         mock_dependencies.slack_notifier.send_failure_notification.assert_called_once()
         mock_dependencies.exit.assert_called_once_with(1)
 

--- a/tests/test_service_quality_oracle.py
+++ b/tests/test_service_quality_oracle.py
@@ -120,7 +120,9 @@ def test_main_succeeds_on_happy_path(oracle_context):
 
     ctx["get_creds"].assert_called_once()
     ctx["load_config"].assert_called_once()
-    ctx["slack"]["create"].assert_called_once_with(MOCK_CONFIG["SLACK_WEBHOOK_URL"])
+    ctx["slack"]["create"].assert_called_once_with(
+        MOCK_CONFIG["SLACK_WEBHOOK_URL"], MOCK_CONFIG["BLOCKCHAIN_CHAIN_ID"]
+    )
 
     ctx["bq_provider_cls"].assert_called_once()
     ctx["bq_provider"].fetch_indexer_issuance_eligibility_data.assert_called_once()

--- a/tests/test_slack_notifier.py
+++ b/tests/test_slack_notifier.py
@@ -11,6 +11,8 @@ from tenacity import wait_fixed
 from src.utils.slack_notifier import SlackNotifier, create_slack_notifier
 
 MOCK_WEBHOOK_URL = "https://hooks.slack.com/services/fake/webhook"
+ARBITRUM_ONE_CHAIN_ID = 42161
+ARBITRUM_SEPOLIA_CHAIN_ID = 421614
 
 
 @pytest.fixture
@@ -41,6 +43,27 @@ def test_create_slack_notifier_returns_none_without_url(url: str):
     """Tests that the factory function returns None if the URL is missing or empty."""
     notifier = create_slack_notifier(url)
     assert notifier is None
+
+
+def test_create_slack_notifier_passes_chain_id_through():
+    """Tests that the factory function labels the notifier with the network of the chain it is given."""
+    notifier = create_slack_notifier(MOCK_WEBHOOK_URL, ARBITRUM_SEPOLIA_CHAIN_ID)
+    assert notifier.network_label == "[TESTNET] :large_brown_circle:"
+
+
+@pytest.mark.parametrize(
+    "chain_id, expected_label",
+    [
+        (ARBITRUM_ONE_CHAIN_ID, "[MAINNET] :large_green_circle:"),
+        (ARBITRUM_SEPOLIA_CHAIN_ID, "[TESTNET] :large_brown_circle:"),
+        (999999, "[CHAIN 999999]"),
+        (None, ""),
+    ],
+)
+def test_network_label_matches_the_chain(chain_id: int, expected_label: str):
+    """Tests that each chain maps to its own label, with unrecognised chains falling back to the chain ID."""
+    notifier = SlackNotifier(MOCK_WEBHOOK_URL, chain_id)
+    assert notifier.network_label == expected_label
 
 
 # 2. Sending Logic Tests
@@ -81,7 +104,7 @@ def test_send_message_retries_on_request_failure(mock_requests: MagicMock):
 
 def test_send_success_notification_builds_correct_payload(mock_requests: MagicMock):
     """Tests that the success notification has the correct structure."""
-    notifier = SlackNotifier(MOCK_WEBHOOK_URL)
+    notifier = SlackNotifier(MOCK_WEBHOOK_URL, ARBITRUM_ONE_CHAIN_ID)
     notifier.send_success_notification(
         eligible_indexers=["0x1"],
         total_processed=10,
@@ -95,7 +118,7 @@ def test_send_success_notification_builds_correct_payload(mock_requests: MagicMo
     payload = call_kwargs["json"]
     attachment = payload["attachments"][0]
 
-    assert payload["text"] == "Rewards Eligibility Oracle - Success"
+    assert payload["text"] == "[MAINNET] :large_green_circle: Rewards Eligibility Oracle - Success"
     assert attachment["color"] == "good"
 
     # Create a map of title to value for easier assertions
@@ -108,14 +131,14 @@ def test_send_success_notification_builds_correct_payload(mock_requests: MagicMo
 
 def test_send_failure_notification_builds_correct_payload(mock_requests: MagicMock):
     """Tests that the failure notification has the correct structure."""
-    notifier = SlackNotifier(MOCK_WEBHOOK_URL)
+    notifier = SlackNotifier(MOCK_WEBHOOK_URL, ARBITRUM_SEPOLIA_CHAIN_ID)
     notifier.send_failure_notification(error_message="Something broke", stage="Test Stage")
 
     call_args, call_kwargs = mock_requests.call_args
     payload = call_kwargs["json"]
     attachment = payload["attachments"][0]
 
-    assert payload["text"] == "Rewards Eligibility Oracle - FAILURE"
+    assert payload["text"] == "[TESTNET] :large_brown_circle: Rewards Eligibility Oracle - FAILURE"
     assert attachment["color"] == "danger"
     fields = {field["title"]: field["value"] for field in attachment["fields"]}
     assert fields["Status"] == "Failed"
@@ -125,14 +148,23 @@ def test_send_failure_notification_builds_correct_payload(mock_requests: MagicMo
 
 def test_send_info_notification_builds_correct_payload(mock_requests: MagicMock):
     """Tests that the info notification has the correct structure."""
-    notifier = SlackNotifier(MOCK_WEBHOOK_URL)
+    notifier = SlackNotifier(MOCK_WEBHOOK_URL, ARBITRUM_SEPOLIA_CHAIN_ID)
     notifier.send_info_notification(message="Just an FYI", title="Friendly Reminder")
 
     call_args, call_kwargs = mock_requests.call_args
     payload = call_kwargs["json"]
     attachment = payload["attachments"][0]
 
-    assert payload["text"] == "Rewards Eligibility Oracle - Friendly Reminder"
+    assert payload["text"] == "[TESTNET] :large_brown_circle: Rewards Eligibility Oracle - Friendly Reminder"
     assert attachment["color"] == "good"  # Default color
     fields = {field["title"]: field["value"] for field in attachment["fields"]}
     assert fields["Message"] == "Just an FYI"
+
+
+def test_notification_is_unlabelled_when_the_chain_is_unknown(mock_requests: MagicMock):
+    """Tests that a notifier without a chain ID sends the message unchanged, with no network prefix."""
+    notifier = SlackNotifier(MOCK_WEBHOOK_URL)
+    notifier.send_info_notification(message="Just an FYI", title="Friendly Reminder")
+
+    call_args, call_kwargs = mock_requests.call_args
+    assert call_kwargs["json"]["text"] == "Rewards Eligibility Oracle - Friendly Reminder"


### PR DESCRIPTION
This PR puts a network label at the start of every Slack notification the oracle sends: [MAINNET] with a green circle for Arbitrum One, [TESTNET] with a brown circle for Arbitrum Sepolia. The testnet and mainnet deployments both post to the same notifications channel, and right now nothing in a message says which one it came from, so two runs that finished a minute apart read as identical successes apart from the RPC provider URL buried in the middle.

The label is derived from the chain ID each deployment is already configured with, so there is nothing extra to set per environment and the label always matches the chain the transactions actually went to. A chain we have no label for falls back to the raw chain ID with a warning in the logs, and if the scheduler fails before its configuration loads, the message goes out unlabelled rather than guessing at a network.